### PR TITLE
Shortcut for default action + no results fix

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,9 +18,16 @@
     ],
     "persistent": false
   },
-  "omnibox": { 
-    "keyword" : "pin" 
-    },
+  "omnibox": {
+    "keyword" : "pin"
+  },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+P"
+      }
+    }
+  },
   "icons": {
     "16": "img/pinboard-16.png",
     "32": "img/pinboard-32.png",

--- a/src/ts/omnibox.ts
+++ b/src/ts/omnibox.ts
@@ -71,7 +71,7 @@ function createSuggestions(pins, searchtext) {
             content: "https://pinboard.in/search/?query=" + encodeURIComponent(searchtext),
             description: "No results found, go to Pinboard search",
         }];
-        if (!pins || pins.size === 0) {
+        if (!pins || pins.length === 0) {
             return resolve(suggestionsOnEmptyResults);
         }
         pins.forEach((pin) => {


### PR DESCRIPTION
I added a shortcut for default action, because I found myself clicking icon and searching a lot.
It involved switching from keyboard to mouse and back, and with the shortcut it should be more streamlined.

Of course, more shortcuts could be added, for example for saving current page, yet this should be a good start.

When looking for better keyboard navigation options, I fixed a small bug occuring when omnibar "pin" search yields no results.